### PR TITLE
Inventory Filters, Tear down toggle, Checkbox

### DIFF
--- a/src/app/inventory/inventory.component.html
+++ b/src/app/inventory/inventory.component.html
@@ -8,7 +8,6 @@
       <mat-option value="all" (click)="ngOnInit()">All</mat-option>
       <mat-option value="joined" (click)="getJoined()">Joined</mat-option>
       <mat-option value="notJoined" (click)="getNotJoined()">Not Joined</mat-option>
-      <!--Joined Not Completed filter not working properly. Can't figure out how to have multiple orderby's from a firebase list -->
       <mat-option value="joinedNotCompleted" (click)="getJoinedNotCompleted()">Joined Not Completed</mat-option>
       <mat-option value="completed" (click)="getComplete()">Completed</mat-option>
     </mat-select>
@@ -30,11 +29,11 @@
       </mat-grid-tile>
       <mat-grid-tile></mat-grid-tile>
       <mat-grid-tile>
-        <mat-slide-toggle [(ngModel)]="myModel">{{setup}}</mat-slide-toggle>
+        <mat-slide-toggle [(ngModel)]="myModel" (change)="toggleSet($event)">{{setUpDown}}</mat-slide-toggle>
       </mat-grid-tile>
   </mat-grid-list>
   <mat-card style="margin: auto;">
-    <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8">
+    <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8" id="items">
 
       <!--- Note that these columns can be defined in any order.
             The actual rendered columns are set as a property on the row definition" -->
@@ -71,6 +70,13 @@
       <ng-container matColumnDef="created_by">
         <th mat-header-cell *matHeaderCellDef mat-sort-header> Created By </th>
         <td mat-cell *matCellDef="let element"> {{element.created_by}} </td>
+      </ng-container>
+
+      <ng-container matColumnDef="checkedIn">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header> Checked In </th>
+        <td mat-cell *matCellDef="let element">
+          <mat-checkbox [checked]="element.checkedIn" (click)="selectCheckedInToggle(element.$key)"></mat-checkbox>
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="joined">
@@ -113,8 +119,8 @@
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
     </table>
-    <mat-paginator [pageSizeOptions]="[20, 50, 100]" showFirstLastButtons></mat-paginator>
-    
+    <mat-paginator [pageSizeOptions]="[20, 50, 100]" showFirstLastButtons id="itemsp"></mat-paginator>
+  
   </mat-card>
 
 <ng-template #mytemplate>

--- a/src/app/inventory/inventory.component.html
+++ b/src/app/inventory/inventory.component.html
@@ -5,11 +5,12 @@
   <mat-grid-tile>
   <mat-form-field>
     <mat-select [(value)]="selected" placeholder="Filter">
-      <mat-option value="all">All</mat-option>
-      <mat-option value="joined">Joined</mat-option>
-      <mat-option value="notJoined">Not Joined</mat-option>
-      <mat-option value="joinedNotCompleted">Joined Not Completed</mat-option>
-      <mat-option value="completed">Completed</mat-option>
+      <mat-option value="all" (click)="ngOnInit()">All</mat-option>
+      <mat-option value="joined" (click)="getJoined()">Joined</mat-option>
+      <mat-option value="notJoined" (click)="getNotJoined()">Not Joined</mat-option>
+      <!--Joined Not Completed filter not working properly. Can't figure out how to have multiple orderby's from a firebase list -->
+      <mat-option value="joinedNotCompleted" (click)="getJoinedNotCompleted()">Joined Not Completed</mat-option>
+      <mat-option value="completed" (click)="getComplete()">Completed</mat-option>
     </mat-select>
   </mat-form-field>
   </mat-grid-tile>
@@ -75,13 +76,13 @@
       <ng-container matColumnDef="joined">
         <th mat-header-cell *matHeaderCellDef mat-sort-header> Joined </th>
         <td mat-cell *matCellDef="let element">
-          <mat-checkbox [checked]="element.joined"></mat-checkbox></td>
+          <mat-checkbox [checked]="element.joined" (click)="selectJoinedToggle(element.$key)"></mat-checkbox></td>
       </ng-container>
       
       <ng-container matColumnDef="complete">
         <th mat-header-cell *matHeaderCellDef mat-sort-header> Complete </th>
         <td mat-cell *matCellDef="let element">
-            <mat-checkbox [checked]="element.complete"></mat-checkbox></td>
+            <mat-checkbox [checked]="element.complete" (click)="selectCompleteToggle(element.$key)"></mat-checkbox></td>
       </ng-container>
     
       <!--{{element.edit}}-->
@@ -103,7 +104,7 @@
         </button>  
         </td>
       </ng-container>
-<!--For testing purposes only -->
+
       <ng-container matColumnDef="key">
         <th mat-header-cell *matHeaderCellDef mat-sort-header> Key </th>
         <td mat-cell *matCellDef="let element"> {{element.$key}} </td>
@@ -112,6 +113,7 @@
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
     </table>
+    <mat-paginator [pageSizeOptions]="[20, 50, 100]" showFirstLastButtons></mat-paginator>
     
   </mat-card>
 

--- a/src/app/inventory/inventory.component.ts
+++ b/src/app/inventory/inventory.component.ts
@@ -190,6 +190,7 @@ export class InventoryComponent implements OnInit {
   
   getJoinedNotCompleted() {
     let data = this.inventoryService.getJoinedNotCompleted();
+    
     data.snapshotChanges().subscribe(item => {
           this.itemList = [];
     
@@ -198,6 +199,7 @@ export class InventoryComponent implements OnInit {
             json["$key"] = element.key;
             this.itemList.push(json as Item);
           });
+      this.itemList = this.itemList.filter(t=>t.joined === true);
       this.dataSource = new MatTableDataSource(this.itemList);
       this.dataSource.sort = this.sort;
       this.dataSource.paginator = this.paginator;

--- a/src/app/inventory/inventory.component.ts
+++ b/src/app/inventory/inventory.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild, Inject } from '@angular/core';
-import { MatSort, MatTableDataSource, MatDialog, MatDialogRef, MatPaginator } from '@angular/material';
+import { MatSort, MatTableDataSource, MatDialog, MatDialogRef, MatPaginator, MatSlideToggleChange } from '@angular/material';
 import { AdditemComponent } from '../additem/additem.component';
 import { InventoryService } from './inventory.service';
 import { Item } from './inventory.model';
@@ -21,6 +21,8 @@ export class InventoryComponent implements OnInit {
   //edit data
   edit = new Item("","","","","",true,true,true);
 
+  setUpDown = "Setup";
+
   dataSource = new MatTableDataSource();
 
   @ViewChild(MatSort) sort: MatSort;
@@ -29,6 +31,8 @@ export class InventoryComponent implements OnInit {
   applyFilter(filterValue: string) {
     this.dataSource.filter = filterValue.trim().toLowerCase();
   }
+
+
 
   constructor(public dialog: MatDialog, private inventoryService: InventoryService) {
     inventoryService.getAllItems();
@@ -128,6 +132,23 @@ export class InventoryComponent implements OnInit {
     }
   }
 
+  selectCheckedInToggle(key: string) {
+    this.selectedItem = this.itemList.filter(x => x.$key === key)[0];
+
+    if (this.selectedItem.checkedIn === true) {
+      let editedItem = new Item(this.selectedItem.mac, this.selectedItem.location, this.selectedItem.port, this.selectedItem.created_at,
+        this.selectedItem.created_by, this.selectedItem.joined, this.selectedItem.complete, false);
+      editedItem.lastUpdate = new Date().toString();
+      this.inventoryService.editItem(this.selectedItem.$key, editedItem);
+    }
+    else {
+      let editedItem = new Item(this.selectedItem.mac, this.selectedItem.location, this.selectedItem.port, this.selectedItem.created_at,
+        this.selectedItem.created_by, this.selectedItem.joined, this.selectedItem.complete, true);
+      editedItem.lastUpdate = new Date().toString();
+      this.inventoryService.editItem(this.selectedItem.$key, editedItem);
+    }
+  }
+
   onSave() {
     let editedItem = new Item(this.edit.mac, this.edit.location, this.edit.port, this.selectedItem.created_at,
       this.selectedItem.created_by, this.selectedItem.joined, this.selectedItem.complete, this.selectedItem.checkedIn);
@@ -137,7 +158,7 @@ export class InventoryComponent implements OnInit {
   }
 
 
-  //Query functions for mat-select
+    //Query functions for mat-select
   getJoined() {
     let data = this.inventoryService.getJoined();
     data.snapshotChanges().subscribe(item => {
@@ -202,5 +223,16 @@ export class InventoryComponent implements OnInit {
       this.dataSource.sort = this.sort;
       this.dataSource.paginator = this.paginator;
       });
+  }
+
+  toggleSet(changeEvent: MatSlideToggleChange) {
+    if (changeEvent.checked) {
+      this.setUpDown = "Tear Down";
+      this.displayedColumns = ['seqNo', 'mac', 'location', 'port', 'checkedIn', 'edit'];
+    }
+    else {
+      this.setUpDown = "Setup";
+      this.displayedColumns = ['seqNo', 'mac', 'location', 'port', 'created_at', 'created_by', 'joined', 'complete', 'edit', 'trash', 'key'];
+    }
   }
 }

--- a/src/app/inventory/inventory.component.ts
+++ b/src/app/inventory/inventory.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild, Inject } from '@angular/core';
-import { MatSort, MatTableDataSource, MatDialog, MatDialogRef } from '@angular/material';
+import { MatSort, MatTableDataSource, MatDialog, MatDialogRef, MatPaginator } from '@angular/material';
 import { AdditemComponent } from '../additem/additem.component';
 import { InventoryService } from './inventory.service';
 import { Item } from './inventory.model';
@@ -24,10 +24,13 @@ export class InventoryComponent implements OnInit {
   dataSource = new MatTableDataSource();
 
   @ViewChild(MatSort) sort: MatSort;
+  @ViewChild(MatPaginator) paginator: MatPaginator;
 
   applyFilter(filterValue: string) {
     this.dataSource.filter = filterValue.trim().toLowerCase();
   }
+
+
 
   constructor(public dialog: MatDialog, private inventoryService: InventoryService) {
     inventoryService.getAllItems();
@@ -67,14 +70,15 @@ export class InventoryComponent implements OnInit {
       });
       this.dataSource = new MatTableDataSource(this.itemList);
       this.dataSource.sort = this.sort;
+      this.dataSource.paginator = this.paginator;
     });
   }
+
 
   //Delete/Edit functions
   onDelete(key: string) {
     this.inventoryService.deletebyKey(key);
   }
-
   
   selectItem(key: string, modal: string) {
     this.selectedItem = this.itemList.filter(x => x.$key === key)[0];
@@ -86,6 +90,45 @@ export class InventoryComponent implements OnInit {
     console.log(this.edit);
   }
 
+  selectJoinedToggle(key: string) {
+    this.selectedItem = this.itemList.filter(x => x.$key === key)[0];
+    if (this.selectedItem.joined === true) {
+      this.edit.joined = false;
+      let editedItem = new Item(this.selectedItem.mac, this.selectedItem.location, this.selectedItem.port, this.selectedItem.created_at,
+        this.selectedItem.created_by, this.edit.joined, this.selectedItem.complete, this.selectedItem.checkedIn);
+      editedItem.lastUpdate = new Date().toString();
+  
+      this.inventoryService.editItem(this.selectedItem.$key, editedItem);
+    }
+    else {
+      this.edit.joined = true;
+      let editedItem = new Item(this.selectedItem.mac, this.selectedItem.location, this.selectedItem.port, this.selectedItem.created_at,
+        this.selectedItem.created_by, this.edit.joined, this.selectedItem.complete, this.selectedItem.checkedIn);
+      editedItem.lastUpdate = new Date().toString();
+  
+      this.inventoryService.editItem(this.selectedItem.$key, editedItem);
+    }
+  }
+
+  selectCompleteToggle(key: string) {
+    this.selectedItem = this.itemList.filter(x => x.$key === key)[0];
+    if (this.selectedItem.complete === true) {
+      this.edit.complete = false;
+      let editedItem = new Item(this.selectedItem.mac, this.selectedItem.location, this.selectedItem.port, this.selectedItem.created_at,
+        this.selectedItem.created_by, this.selectedItem.joined, this.edit.complete, this.selectedItem.checkedIn);
+      editedItem.lastUpdate = new Date().toString();
+  
+      this.inventoryService.editItem(this.selectedItem.$key, editedItem);
+    }
+    else {
+      this.edit.joined = true;
+      let editedItem = new Item(this.selectedItem.mac, this.selectedItem.location, this.selectedItem.port, this.selectedItem.created_at,
+        this.selectedItem.created_by, this.selectedItem.joined, true, this.selectedItem.checkedIn);
+      editedItem.lastUpdate = new Date().toString();
+  
+      this.inventoryService.editItem(this.selectedItem.$key, editedItem);
+    }
+  }
 
   onSave() {
     let editedItem = new Item(this.edit.mac, this.edit.location, this.edit.port, this.selectedItem.created_at,
@@ -95,4 +138,69 @@ export class InventoryComponent implements OnInit {
     this.inventoryService.editItem(this.selectedItem.$key, editedItem);
   }
 
+
+    //Query functions for mat-select
+  getJoined() {
+    let data = this.inventoryService.getJoined();
+    data.snapshotChanges().subscribe(item => {
+        this.itemList = [];
+  
+      item.forEach(element => {
+          let json = element.payload.toJSON();
+          json["$key"] = element.key;
+          this.itemList.push(json as Item);
+        });
+      this.dataSource = new MatTableDataSource(this.itemList);
+      this.dataSource.sort = this.sort;
+      this.dataSource.paginator = this.paginator;
+      });
+    }
+  
+  getComplete() {
+    let data = this.inventoryService.getCompleted();
+    data.snapshotChanges().subscribe(item => {
+        this.itemList = [];
+  
+      item.forEach(element => {
+          let json = element.payload.toJSON();
+          json["$key"] = element.key;
+          this.itemList.push(json as Item);
+        });
+      this.dataSource = new MatTableDataSource(this.itemList);
+      this.dataSource.sort = this.sort;
+      this.dataSource.paginator = this.paginator;
+      });
+    }
+
+  getNotJoined() {
+    let data = this.inventoryService.getNotJoined();
+    data.snapshotChanges().subscribe(item => {
+          this.itemList = [];
+    
+      item.forEach(element => {
+            let json = element.payload.toJSON();
+            json["$key"] = element.key;
+            this.itemList.push(json as Item);
+          });
+        this.dataSource = new MatTableDataSource(this.itemList);
+        this.dataSource.sort = this.sort;
+        this.dataSource.paginator = this.paginator;
+        });
+    }
+  
+  getJoinedNotCompleted() {
+    let data = this.inventoryService.getJoinedNotCompleted();
+    data.snapshotChanges().subscribe(item => {
+          this.itemList = [];
+    
+      item.forEach(element => {
+            let json = element.payload.toJSON();
+            json["$key"] = element.key;
+            this.itemList.push(json as Item);
+          });
+      this.dataSource = new MatTableDataSource(this.itemList);
+      this.dataSource.sort = this.sort;
+      this.dataSource.paginator = this.paginator;
+      });
+  }
 }

--- a/src/app/inventory/inventory.component.ts
+++ b/src/app/inventory/inventory.component.ts
@@ -30,8 +30,6 @@ export class InventoryComponent implements OnInit {
     this.dataSource.filter = filterValue.trim().toLowerCase();
   }
 
-
-
   constructor(public dialog: MatDialog, private inventoryService: InventoryService) {
     inventoryService.getAllItems();
   }
@@ -139,7 +137,7 @@ export class InventoryComponent implements OnInit {
   }
 
 
-    //Query functions for mat-select
+  //Query functions for mat-select
   getJoined() {
     let data = this.inventoryService.getJoined();
     data.snapshotChanges().subscribe(item => {

--- a/src/app/inventory/inventory.component.ts
+++ b/src/app/inventory/inventory.component.ts
@@ -22,6 +22,11 @@ export class InventoryComponent implements OnInit {
   edit = new Item("","","","","",true,true,true);
 
   setUpDown = "Setup";
+  countAll: number;
+  countJoined: number;
+  countCompleted: number;
+  countCheckedIn: number;
+  selected: string;
 
   dataSource = new MatTableDataSource();
 
@@ -32,11 +37,11 @@ export class InventoryComponent implements OnInit {
     this.dataSource.filter = filterValue.trim().toLowerCase();
   }
 
-
-
   constructor(public dialog: MatDialog, private inventoryService: InventoryService) {
     inventoryService.getAllItems();
   }
+
+
 
   //Additem dialog open
   openDialog(): void {
@@ -80,6 +85,7 @@ export class InventoryComponent implements OnInit {
   //Delete/Edit functions
   onDelete(key: string) {
     this.inventoryService.deletebyKey(key);
+    this.refreshAfterEdit();
   }
   
   selectItem(key: string, modal: string) {
@@ -110,6 +116,7 @@ export class InventoryComponent implements OnInit {
   
       this.inventoryService.editItem(this.selectedItem.$key, editedItem);
     }
+    this.refreshAfterEdit();
   }
 
   selectCompleteToggle(key: string) {
@@ -130,6 +137,7 @@ export class InventoryComponent implements OnInit {
   
       this.inventoryService.editItem(this.selectedItem.$key, editedItem);
     }
+    this.refreshAfterEdit();
   }
 
   selectCheckedInToggle(key: string) {
@@ -147,6 +155,7 @@ export class InventoryComponent implements OnInit {
       editedItem.lastUpdate = new Date().toString();
       this.inventoryService.editItem(this.selectedItem.$key, editedItem);
     }
+    this.refreshAfterEdit();
   }
 
   onSave() {
@@ -155,12 +164,31 @@ export class InventoryComponent implements OnInit {
     editedItem.lastUpdate = new Date().toString();
 
     this.inventoryService.editItem(this.selectedItem.$key, editedItem);
+    this.refreshAfterEdit();
   }
 
+  //After edit, refresh query
+  refreshAfterEdit() {
+    if (this.selected === 'joined') {
+      this.getJoined();
+    }
+    else if (this.selected === 'notJoined') {
+      this.getNotJoined();
+    }
+    else if (this.selected === 'joinedNotCompleted') {
+      this.getJoinedNotCompleted();
+    }
+    else if (this.selected === 'completed') {
+      this.getComplete();
+    }
+    else {
+      this.ngOnInit();
+    }
+  }
 
     //Query functions for mat-select
   getJoined() {
-    let data = this.inventoryService.getJoined();
+    let data = this.inventoryService.getTrue('joined');
     data.snapshotChanges().subscribe(item => {
         this.itemList = [];
   
@@ -176,7 +204,7 @@ export class InventoryComponent implements OnInit {
     }
   
   getComplete() {
-    let data = this.inventoryService.getCompleted();
+    let data = this.inventoryService.getTrue('complete');
     data.snapshotChanges().subscribe(item => {
         this.itemList = [];
   
@@ -192,7 +220,7 @@ export class InventoryComponent implements OnInit {
     }
 
   getNotJoined() {
-    let data = this.inventoryService.getNotJoined();
+    let data = this.inventoryService.getFalse('joined');
     data.snapshotChanges().subscribe(item => {
           this.itemList = [];
     
@@ -208,8 +236,7 @@ export class InventoryComponent implements OnInit {
     }
   
   getJoinedNotCompleted() {
-    let data = this.inventoryService.getJoinedNotCompleted();
-    
+    let data = this.inventoryService.getFalse('complete');
     data.snapshotChanges().subscribe(item => {
           this.itemList = [];
     

--- a/src/app/inventory/inventory.service.ts
+++ b/src/app/inventory/inventory.service.ts
@@ -50,7 +50,6 @@ export class InventoryService {
     return this.queryList;
   }
 
-  //Needs work. Only returns non-completed items even if item.joined is true
   getJoinedNotCompleted() {
     this.queryList = this.db.list('items', ref => ref.orderByChild('complete').equalTo(false));
     return this.queryList;

--- a/src/app/inventory/inventory.service.ts
+++ b/src/app/inventory/inventory.service.ts
@@ -35,23 +35,13 @@ export class InventoryService {
     this.db.object('/items/' + key).update(item);
   }
 
-  getJoined() {
-    this.queryList = this.db.list('items', ref => ref.orderByChild('joined').equalTo(true));
+  getTrue(thing: string) {
+    this.queryList = this.db.list('items', ref => ref.orderByChild(thing).equalTo(true));
     return this.queryList;
   }
 
-  getCompleted() {
-    this.queryList = this.db.list('items', ref => ref.orderByChild('complete').equalTo(true));
-    return this.queryList;
-  }
-
-  getNotJoined() {
-    this.queryList = this.db.list('items', ref => ref.orderByChild('joined').equalTo(false));
-    return this.queryList;
-  }
-
-  getJoinedNotCompleted() {
-    this.queryList = this.db.list('items', ref => ref.orderByChild('complete').equalTo(false));
+  getFalse(thing: string) {
+    this.queryList = this.db.list('items', ref => ref.orderByChild(thing).equalTo(false));
     return this.queryList;
   }
 }

--- a/src/app/inventory/inventory.service.ts
+++ b/src/app/inventory/inventory.service.ts
@@ -10,6 +10,8 @@ import 'firebase/storage';
 export class InventoryService {
   item: Item;
   itemList: AngularFireList<any>;
+  queryList: AngularFireList<any>;
+  noncompleteJoined: AngularFireList<any>;
   selectedItem: Item;
   constructor(private db: AngularFireDatabase, private firebaseApp: FirebaseApp) {
 
@@ -31,5 +33,26 @@ export class InventoryService {
 
   editItem(key: string, item: Item) {
     this.db.object('/items/' + key).update(item);
+  }
+
+  getJoined() {
+    this.queryList = this.db.list('items', ref => ref.orderByChild('joined').equalTo(true));
+    return this.queryList;
+  }
+
+  getCompleted() {
+    this.queryList = this.db.list('items', ref => ref.orderByChild('complete').equalTo(true));
+    return this.queryList;
+  }
+
+  getNotJoined() {
+    this.queryList = this.db.list('items', ref => ref.orderByChild('joined').equalTo(false));
+    return this.queryList;
+  }
+
+  //Needs work. Only returns non-completed items even if item.joined is true
+  getJoinedNotCompleted() {
+    this.queryList = this.db.list('items', ref => ref.orderByChild('complete').equalTo(false));
+    return this.queryList;
   }
 }


### PR DESCRIPTION
Added filters for Inventory page.
Added Toggle for Tear down, and Setup
Added functionality to checkboxes.

~~There is some weird things happening I think with two way binding. So say you select a filter, and then edit an item from that filter, It can bug out a bit and refresh the list without the filter.~~
Edit: Fixed this problem